### PR TITLE
fix: remove the checking if metadata are already cached by filename

### DIFF
--- a/src/shared/metadata-saver.js
+++ b/src/shared/metadata-saver.js
@@ -22,14 +22,6 @@ export const saveMetadata = _metadataArray => {
 		return Promise.resolve()
 	}
 
-	// Check if all metadata entries are already cached (by filename)
-	const allCached = metadataArray.every( entry => getCachedMetadata( entry.filename ) )
-	if ( allCached ) {
-		// eslint-disable-next-line no-console
-		// console.log( 'Metadata already saved successfully for all filenames:', metadataArray.map( m => m.filename ) )
-		return Promise.resolve()
-	}
-
 	// Mark all as successful in cache, keep a local copy of the metadata
 	metadataArray.forEach( entry => {
 		if ( entry.filename ) {


### PR DESCRIPTION
fixes #8 

This check prevents the saving of the metadata since it assumes that files of the same filename are the same.

Checked the behavior for the following:
- [x] Uploading a file, closing the media library, and uploading a different file with the same name
- [x] Uploading of different files with the same name at the same time
- [x] Uploading of different file types (audio, image, video)