### PR TITLE
fix: allow dropping in the Media manager without waiting for the .med…

### DIFF
--- a/src/admin/js/media-manager/drop-zone.js
+++ b/src/admin/js/media-manager/drop-zone.js
@@ -46,6 +46,7 @@ function addDropZoneListenerToMediaManager( targetDocument ) {
 		// is triggered. We might break other funcitonality that we don't have
 		// the conversion to happen.
 		if ( ! event.target.closest( '.media-frame-uploader' ) && // Allowed to drop in the Media Manager
+			! event.target.closest( '.supports-drag-drop' ).querySelector( '.media-frame-uploader' ) && // Allowed a fallback to drop in the Media Manager
 			! event.target.closest( '.media-upload-form' ) && // Allowed to drop in the admin Media > Add Media File.
 			! event.target.closest( '.editor-post-featured-image' ) && // Allowed to drop in the featured image drop zone.
 			! event.target.closest( '.editor-styles-wrapper' ) && // Allowed to drop in the block editor when adding new image blocks


### PR DESCRIPTION
…ia-frame-uploader to engage

fixes #3

**Issue:** When dropping a media without waiting for the `.media-frame-uploader` to engage (quickly dropping without waiting for the blue drop indicator), the target becomes the HTML element where the drop happened. This fix uses a fallback to allow dropping inside the Media Manager modal.