### PR TITLE
feat: add avif support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
 				"@jsquash/avif": "^2.1.1",
 				"@mediabunny/mp3-encoder": "^1.25.0",
 				"heic2any": "^0.0.4",
-				"mediabunny": "^1.25.0"
+				"mediabunny": "^1.25.0",
+				"svgo": "^4.0.0"
 			},
 			"devDependencies": {
 				"@wordpress/eslint-plugin": "^22.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
 	"name": "cimo",
-	"version": "1.1.2",
+	"version": "1.2.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cimo",
-			"version": "1.1.2",
+			"version": "1.2.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@jsquash/avif": "^2.1.1",
 				"@mediabunny/mp3-encoder": "^1.25.0",
 				"mediabunny": "^1.25.0"
 			},
@@ -2592,6 +2593,15 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@jsquash/avif": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@jsquash/avif/-/avif-2.1.1.tgz",
+			"integrity": "sha512-LMRxd0fMgfCLtobDh0/sFYJMMiRJTNYSEEWvRDKXlAeZ08t3gI5V+1thIT0XjXJ+SVG7Zug9B0XPyx0Ti5VRNA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"wasm-feature-detect": "^1.2.11"
 			}
 		},
 		"node_modules/@keyv/serialize": {
@@ -19134,6 +19144,12 @@
 			"dependencies": {
 				"makeerror": "1.0.12"
 			}
+		},
+		"node_modules/wasm-feature-detect": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+			"integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/watchpack": {
 			"version": "2.4.4",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"prettier": "^3.3.3"
 	},
 	"dependencies": {
+		"@jsquash/avif": "^2.1.1",
 		"@mediabunny/mp3-encoder": "^1.25.0",
 		"mediabunny": "^1.25.0"
 	}

--- a/src/admin/class-admin.php
+++ b/src/admin/class-admin.php
@@ -56,6 +56,9 @@ if ( ! class_exists( 'Cimo_Admin' ) ) {
 						'schema' => [
 							'type' => 'object',
 							'properties' => [
+								'image_output_format' => [
+									'type' => 'string',
+								],
 								'webp_quality' => [
 									'type' => 'integer',
 								],
@@ -217,6 +220,11 @@ if ( ! class_exists( 'Cimo_Admin' ) ) {
 			// Load up the complete options so we don't lose any existing settings.
 			$current = get_option( 'cimo_options', [] );
 			$sanitized = is_array( $current ) ? $current : [];
+
+			// Sanitize image output format
+			if ( isset( $options['image_output_format'] ) ) {
+				$sanitized['image_output_format'] = sanitize_text_field( $options['image_output_format'] );
+			}
 
 			// Sanitize webp quality
 			if ( isset( $options['webp_quality'] ) ) {

--- a/src/admin/class-admin.php
+++ b/src/admin/class-admin.php
@@ -58,6 +58,7 @@ if ( ! class_exists( 'Cimo_Admin' ) ) {
 							'properties' => [
 								'image_output_format' => [
 									'type' => 'string',
+									'enum' => [ 'webp', 'avif' ],
 								],
 								'webp_quality' => [
 									'type' => 'integer',
@@ -223,7 +224,8 @@ if ( ! class_exists( 'Cimo_Admin' ) ) {
 
 			// Sanitize image output format
 			if ( isset( $options['image_output_format'] ) ) {
-				$sanitized['image_output_format'] = sanitize_text_field( $options['image_output_format'] );
+				$format = sanitize_text_field( $options['image_output_format'] );
+				$sanitized['image_output_format'] = in_array( $format, [ 'webp', 'avif' ], true ) ? $format : 'webp';
 			}
 
 			// Sanitize webp quality

--- a/src/admin/class-script-loader.php
+++ b/src/admin/class-script-loader.php
@@ -84,6 +84,7 @@ if ( ! class_exists( 'Cimo_Script_Loader' ) ) {
 				[
 					'restUrl' => rest_url( 'cimo/v1/' ),
 					'nonce'   => wp_create_nonce( 'wp_rest' ),
+					'imageOutputFormat' => ! empty( $settings['image_output_format'] ) ? $settings['image_output_format'] : 'webp',
 					'webpQuality' => ! empty( $settings['webp_quality'] ) ? (int) $settings['webp_quality'] : 80,
 					'maxImageDimension' => ! empty( $settings['max_image_dimension'] ) ? (int) $settings['max_image_dimension'] : 0,
 					'videoOptimizationEnabled' => isset( $settings['video_optimization_enabled'] ) ? (int) $settings['video_optimization_enabled'] : 1,

--- a/src/admin/class-script-loader.php
+++ b/src/admin/class-script-loader.php
@@ -84,6 +84,7 @@ if ( ! class_exists( 'Cimo_Script_Loader' ) ) {
 				[
 					'restUrl' => rest_url( 'cimo/v1/' ),
 					'nonce'   => wp_create_nonce( 'wp_rest' ),
+					'isPremium' => CIMO_BUILD === 'premium',
 					'imageOutputFormat' => ! empty( $settings['image_output_format'] ) ? $settings['image_output_format'] : 'webp',
 					'webpQuality' => ! empty( $settings['webp_quality'] ) ? (int) $settings['webp_quality'] : 80,
 					'maxImageDimension' => ! empty( $settings['max_image_dimension'] ) ? (int) $settings['max_image_dimension'] : 0,

--- a/src/admin/css/admin-page.css
+++ b/src/admin/css/admin-page.css
@@ -144,6 +144,13 @@
 	gap: 20px;
 }
 
+.cimo-radio-option-label {
+	display: flex;
+	justify-content: start;
+	align-items: center;
+	gap: 12px;
+}
+
 .cimo-submit-buttons {
 	display: flex;
 	gap: 12px;

--- a/src/admin/js/media-manager/drop-zone.js
+++ b/src/admin/js/media-manager/drop-zone.js
@@ -34,8 +34,8 @@ function addDropZoneListenerToMediaManager( targetDocument ) {
 		}
 
 		// Get the file converters for the incoming files.
-		const fileConverters = Array.from( event.dataTransfer.files )
-			.map( file => getFileConverter( file ) )
+		const files = Array.from( event.dataTransfer.files )
+		const fileConverters = await Promise.all( files.map( file => getFileConverter( file ) ) )
 
 		// Do not continue if we do not need to convert any files.
 		if ( ! requiresFileConversion( fileConverters ) ) {

--- a/src/admin/js/media-manager/drop-zone.js
+++ b/src/admin/js/media-manager/drop-zone.js
@@ -33,14 +33,8 @@ function addDropZoneListenerToMediaManager( targetDocument ) {
 			return
 		}
 
-		// Get the file converters for the incoming files.
+		// Get the files from the input
 		const files = Array.from( event.dataTransfer.files )
-		const fileConverters = await Promise.all( files.map( file => getFileConverter( file ) ) )
-
-		// Do not continue if we do not need to convert any files.
-		if ( ! requiresFileConversion( fileConverters ) ) {
-			return
-		}
 
 		// TODO: We also want to filter out the target so we can set when this
 		// is triggered. We might break other funcitonality that we don't have
@@ -54,16 +48,25 @@ function addDropZoneListenerToMediaManager( targetDocument ) {
 			return
 		}
 
+		// Prevent default browser behavior
+		// This must happen before any async operations
+		event.preventDefault()
+		event.stopPropagation()
+
+		// Get the file converters for the incoming files.
+		const fileConverters = await Promise.all( files.map( file => getFileConverter( file ) ) )
+
+		// Do not continue if we do not need to convert any files.
+		if ( ! requiresFileConversion( fileConverters ) ) {
+			return
+		}
+
 		// DEV NOTE: Previously, we did a return here if the browser didn't
 		// support webp (this worked for Safari), this makes it so that the
 		// normal processing happens instead of our "interceptor". But since we
 		// want to support a mix of video/audio/image files, we can't just stop
 		// the entire handling of the drop event. We now just return the
 		// original file but still proceed with our conversion logic.
-
-		// Prevent default browser behavior
-		event.preventDefault()
-		event.stopPropagation()
 
 		// Hide the drop files to upload note. Sometimes, like in Elementor, if
 		// there are multiple media managers opened, this can be many, hide them

--- a/src/admin/js/media-manager/drop-zone.js
+++ b/src/admin/js/media-manager/drop-zone.js
@@ -33,8 +33,14 @@ function addDropZoneListenerToMediaManager( targetDocument ) {
 			return
 		}
 
-		// Get the files from the input
+		// Get the file converters for the incoming files.
 		const files = Array.from( event.dataTransfer.files )
+		const fileConverters = await Promise.all( files.map( file => getFileConverter( file ) ) )
+
+		// Do not continue if we do not need to convert any files.
+		if ( ! requiresFileConversion( fileConverters ) ) {
+			return
+		}
 
 		// TODO: We also want to filter out the target so we can set when this
 		// is triggered. We might break other funcitonality that we don't have
@@ -48,25 +54,16 @@ function addDropZoneListenerToMediaManager( targetDocument ) {
 			return
 		}
 
-		// Prevent default browser behavior
-		// This must happen before any async operations
-		event.preventDefault()
-		event.stopPropagation()
-
-		// Get the file converters for the incoming files.
-		const fileConverters = await Promise.all( files.map( file => getFileConverter( file ) ) )
-
-		// Do not continue if we do not need to convert any files.
-		if ( ! requiresFileConversion( fileConverters ) ) {
-			return
-		}
-
 		// DEV NOTE: Previously, we did a return here if the browser didn't
 		// support webp (this worked for Safari), this makes it so that the
 		// normal processing happens instead of our "interceptor". But since we
 		// want to support a mix of video/audio/image files, we can't just stop
 		// the entire handling of the drop event. We now just return the
 		// original file but still proceed with our conversion logic.
+
+		// Prevent default browser behavior
+		event.preventDefault()
+		event.stopPropagation()
 
 		// Hide the drop files to upload note. Sometimes, like in Elementor, if
 		// there are multiple media managers opened, this can be many, hide them

--- a/src/admin/js/media-manager/select-files.js
+++ b/src/admin/js/media-manager/select-files.js
@@ -33,8 +33,14 @@ function addSelectFilesListenerToFileUploads( targetDocument ) {
 			return
 		}
 
-		// Get the files from the input
+		// Get the file converters for the incoming files.
 		const files = Array.from( event.target.files )
+		const fileConverters = await Promise.all( files.map( file => getFileConverter( file ) ) )
+
+		// Do not continue if we do not need to convert any files.
+		if ( ! requiresFileConversion( fileConverters ) ) {
+			return
+		}
 
 		// TODO: We need filter this so that we will only override this on file
 		// selects that we want to, like the media manager picker or the image
@@ -47,26 +53,17 @@ function addSelectFilesListenerToFileUploads( targetDocument ) {
 			return
 		}
 
-		// Prevent the default file handling
-		// This must happen before any async operations
-		event.preventDefault()
-		event.stopPropagation()
-		event.stopImmediatePropagation()
-
-		// Get the file converters for the incoming files.
-		const fileConverters = await Promise.all( files.map( file => getFileConverter( file ) ) )
-
-		// Do not continue if we do not need to convert any files.
-		if ( ! requiresFileConversion( fileConverters ) ) {
-			return
-		}
-
 		// DEV NOTE: Previously, we did a return here if the browser didn't
 		// support webp (this worked for Safari), this makes it so that the
 		// normal processing happens instead of our "interceptor". But since we
 		// want to support a mix of video/audio/image files, we can't just stop
 		// the entire handling of the drop event. We now just return the
 		// original file but still proceed with our conversion logic.
+
+		// Prevent the default file handling
+		event.preventDefault()
+		event.stopPropagation()
+		event.stopImmediatePropagation()
 
 		// Cancel the conversion if the user closes the progress modal.
 		const onCancel = () => {

--- a/src/admin/js/media-manager/select-files.js
+++ b/src/admin/js/media-manager/select-files.js
@@ -33,14 +33,8 @@ function addSelectFilesListenerToFileUploads( targetDocument ) {
 			return
 		}
 
-		// Get the file converters for the incoming files.
+		// Get the files from the input
 		const files = Array.from( event.target.files )
-		const fileConverters = await Promise.all( files.map( file => getFileConverter( file ) ) )
-
-		// Do not continue if we do not need to convert any files.
-		if ( ! requiresFileConversion( fileConverters ) ) {
-			return
-		}
 
 		// TODO: We need filter this so that we will only override this on file
 		// selects that we want to, like the media manager picker or the image
@@ -53,17 +47,26 @@ function addSelectFilesListenerToFileUploads( targetDocument ) {
 			return
 		}
 
+		// Prevent the default file handling
+		// This must happen before any async operations
+		event.preventDefault()
+		event.stopPropagation()
+		event.stopImmediatePropagation()
+
+		// Get the file converters for the incoming files.
+		const fileConverters = await Promise.all( files.map( file => getFileConverter( file ) ) )
+
+		// Do not continue if we do not need to convert any files.
+		if ( ! requiresFileConversion( fileConverters ) ) {
+			return
+		}
+
 		// DEV NOTE: Previously, we did a return here if the browser didn't
 		// support webp (this worked for Safari), this makes it so that the
 		// normal processing happens instead of our "interceptor". But since we
 		// want to support a mix of video/audio/image files, we can't just stop
 		// the entire handling of the drop event. We now just return the
 		// original file but still proceed with our conversion logic.
-
-		// Prevent the default file handling
-		event.preventDefault()
-		event.stopPropagation()
-		event.stopImmediatePropagation()
 
 		// Cancel the conversion if the user closes the progress modal.
 		const onCancel = () => {

--- a/src/admin/js/media-manager/select-files.js
+++ b/src/admin/js/media-manager/select-files.js
@@ -34,8 +34,8 @@ function addSelectFilesListenerToFileUploads( targetDocument ) {
 		}
 
 		// Get the file converters for the incoming files.
-		const fileConverters = Array.from( event.target.files )
-			.map( file => getFileConverter( file ) )
+		const files = Array.from( event.target.files )
+		const fileConverters = await Promise.all( files.map( file => getFileConverter( file ) ) )
 
 		// Do not continue if we do not need to convert any files.
 		if ( ! requiresFileConversion( fileConverters ) ) {

--- a/src/admin/js/page/admin-settings.js
+++ b/src/admin/js/page/admin-settings.js
@@ -427,7 +427,7 @@ const AdminSettings = () => {
 						<div className="cimo-setting-field">
 							<RangeControl
 								id="webpQuality"
-								label={ __( 'WebP Image Quality', 'cimo-image-optimizer' ) }
+								label={ __( 'Image Quality', 'cimo-image-optimizer' ) }
 								value={ settings.webpQuality || '' }
 								onChange={ value => handleInputChange( 'webpQuality', value || '' ) }
 								min="1"

--- a/src/admin/js/page/admin-settings.js
+++ b/src/admin/js/page/admin-settings.js
@@ -15,6 +15,7 @@ const buildType = applyFilters( 'cimo.admin.settings.buildType', 'free' )
 
 const AdminSettings = () => {
 	const [ settings, setSettings ] = useState( {
+		imageOutputFormat: 'webp',
 		webpQuality: 80,
 		maxImageDimension: '',
 		disableWpScaling: 1,
@@ -71,6 +72,7 @@ const AdminSettings = () => {
 			const cimoOptions = data.cimo_options || {}
 			const fetchedSettings = {
 				// Image Optimization settings
+				imageOutputFormat: cimoOptions.image_output_format || 'webp',
 				webpQuality: cimoOptions.webp_quality !== undefined ? cimoOptions.webp_quality : 80,
 				maxImageDimension: cimoOptions.max_image_dimension || '',
 				disableWpScaling: cimoOptions.disable_wp_scaling !== undefined ? cimoOptions.disable_wp_scaling : 1,
@@ -132,6 +134,7 @@ const AdminSettings = () => {
 		setSettings( settings => {
 			return {
 				...settings,
+				imageOutputFormat: 'webp',
 				webpQuality: 80,
 				maxImageDimension: 1920,
 				disableWpScaling: 1,
@@ -145,6 +148,7 @@ const AdminSettings = () => {
 		setSettings( settings => {
 			return {
 				...settings,
+				imageOutputFormat: 'webp',
 				webpQuality: '',
 				maxImageDimension: '',
 				disableWpScaling: 1,
@@ -229,6 +233,7 @@ const AdminSettings = () => {
 				data: {
 					cimo_options: {
 						// Image Optimization settings
+						image_output_format: settings.imageOutputFormat,
 						webp_quality: parseInt( settings.webpQuality ) || 0,
 						max_image_dimension: parseInt( settings.maxImageDimension ) || 0,
 						disable_wp_scaling: settings.disableWpScaling,
@@ -395,6 +400,28 @@ const AdminSettings = () => {
 							>
 								{ __( 'Recommended', 'cimo-image-optimizer' ) }
 							</Button>
+						</div>
+
+						<div className="cimo-setting-field">
+							<ToggleGroupControl
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+								label={ __( 'Image Output Format', 'cimo-image-optimizer' ) }
+								value={ settings.imageOutputFormat || 'webp' }
+								onChange={ value => handleInputChange( 'imageOutputFormat', value ) }
+								isBlock
+								help={ __( 'Set the resulting format of the optimized files.', 'cimo-image-optimizer' ) }
+							>
+								<ToggleGroupControlOption
+									value="webp"
+									label={ __( 'WebP', 'cimo-image-optimizer' ) }
+								/>
+								<ToggleGroupControlOption
+									value="avif"
+									label={ __( 'AVIF', 'cimo-image-optimizer' ) }
+									disabled={ buildType === 'free' }
+								/>
+							</ToggleGroupControl>
 						</div>
 
 						<div className="cimo-setting-field">

--- a/src/admin/js/page/admin-settings.js
+++ b/src/admin/js/page/admin-settings.js
@@ -2,7 +2,7 @@ import {
 	useState, useEffect, useCallback,
 } from '@wordpress/element'
 import {
-	Button, RangeControl, ToggleControl, TextControl,
+	Button, RangeControl, ToggleControl, TextControl, RadioControl,
 	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components'
@@ -403,25 +403,19 @@ const AdminSettings = () => {
 						</div>
 
 						<div className="cimo-setting-field">
-							<ToggleGroupControl
+							<RadioControl
 								__nextHasNoMarginBottom
 								__next40pxDefaultSize
 								label={ __( 'Image Output Format', 'cimo-image-optimizer' ) }
-								value={ settings.imageOutputFormat || 'webp' }
+								selected={ settings.imageOutputFormat || 'webp' }
 								onChange={ value => handleInputChange( 'imageOutputFormat', value ) }
 								isBlock
+								options={ [
+									{ label: 'WebP', value: 'webp' },
+									{ label: 'AVIF', value: 'avif' },
+								] }
 								help={ __( 'Set the resulting format of the optimized files.', 'cimo-image-optimizer' ) }
-							>
-								<ToggleGroupControlOption
-									value="webp"
-									label={ __( 'WebP', 'cimo-image-optimizer' ) }
-								/>
-								<ToggleGroupControlOption
-									value="avif"
-									label={ __( 'AVIF', 'cimo-image-optimizer' ) }
-									disabled={ buildType === 'free' }
-								/>
-							</ToggleGroupControl>
+							/>
 						</div>
 
 						<div className="cimo-setting-field">

--- a/src/admin/js/page/admin-settings.js
+++ b/src/admin/js/page/admin-settings.js
@@ -477,7 +477,7 @@ const AdminSettings = () => {
 								__next40pxDefaultSize
 								allowReset
 								initialPosition={ 80 }
-								help={ __( 'Set the quality / compression level for generated .webp images. Default is 80%. Higher values mean better quality and larger file size; lower values reduce file size with more compression but lower quality.', 'cimo-image-optimizer' ) }
+								help={ __( 'Set the quality / compression level for generated images. Default is 80%. Higher values mean better quality and larger file size; lower values reduce file size with more compression but lower quality.', 'cimo-image-optimizer' ) }
 							/>
 						</div>
 						{ /* Maximum Image Dimension */ }

--- a/src/admin/js/page/admin-settings.js
+++ b/src/admin/js/page/admin-settings.js
@@ -76,7 +76,7 @@ const AdminSettings = () => {
 			const cimoOptions = data.cimo_options || {}
 			const fetchedSettings = {
 				// Image Optimization settings
-				imageOutputFormat: cimoOptions.image_output_format || 'webp',
+				imageOutputFormat: buildType === 'free' ? 'webp' : cimoOptions.image_output_format || 'webp',
 				webpQuality: cimoOptions.webp_quality !== undefined ? cimoOptions.webp_quality : 80,
 				maxImageDimension: cimoOptions.max_image_dimension || '',
 				disableWpScaling: cimoOptions.disable_wp_scaling !== undefined ? cimoOptions.disable_wp_scaling : 1,
@@ -430,13 +430,38 @@ const AdminSettings = () => {
 								__next40pxDefaultSize
 								label={ __( 'Image Output Format', 'cimo-image-optimizer' ) }
 								selected={ settings.imageOutputFormat || 'webp' }
-								onChange={ value => handleInputChange( 'imageOutputFormat', value ) }
+								onChange={ value => {
+									if ( buildType === 'free' && value === 'avif' ) {
+										return
+									}
+									handleInputChange( 'imageOutputFormat', value )
+								} }
 								isBlock
 								options={ [
-									{ label: 'WebP', value: 'webp' },
-									{ label: 'AVIF', value: 'avif' },
+									{
+										label: 'WebP',
+										value: 'webp',
+									},
+									{
+										label: (
+											<div className="cimo-radio-option-label">
+												<span style={ buildType === 'free' ? { opacity: 0.5, pointerEvents: 'none' } : null }>
+													{ __( 'AVIF', 'cimo-image-optimizer' ) }
+												</span>
+												{ buildType === 'free' && (
+													<span
+														className="cimo-premium-feature-label"
+													>
+														<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-lock-icon lucide-lock"><rect width="18" height="11" x="3" y="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" /></svg>
+														{ __( 'Premium', 'cimo-image-optimizer' ) }
+													</span>
+												) }
+											</div>
+										),
+										value: 'avif',
+									},
 								] }
-								help={ __( 'Set the resulting format of the optimized files.', 'cimo-image-optimizer' ) }
+								help={ __( 'Set the resulting format of the optimized files. If AVIF is not supported, it will fallback to WebP.', 'cimo-image-optimizer' ) }
 							/>
 						</div>
 
@@ -954,6 +979,15 @@ const AdminSettings = () => {
 							</span>
 							<span>
 								{ __( 'Optimize SVG files on upload', 'cimo-image-optimizer' ) }
+							</span>
+						</li>
+						<li>
+							<span className="cimo-premium-icon">
+								{ /* AVIF Icon */ }
+								<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-fast-forward-icon lucide-fast-forward"><path d="M12 6a2 2 0 0 1 3.414-1.414l6 6a2 2 0 0 1 0 2.828l-6 6A2 2 0 0 1 12 18z" /><path d="M2 6a2 2 0 0 1 3.414-1.414l6 6a2 2 0 0 1 0 2.828l-6 6A2 2 0 0 1 2 18z" /></svg>
+							</span>
+							<span>
+								{ __( 'Support for AVIF format', 'cimo-image-optimizer' ) }
 							</span>
 						</li>
 						<hr />

--- a/src/shared/converters/image-converter.js
+++ b/src/shared/converters/image-converter.js
@@ -177,17 +177,8 @@ class ImageConverter extends Converter {
 				// Only use quality for lossy formats
 				const q = ( outputFormat === 'webp' || outputFormat === 'jpg' || outputFormat === 'avif' ) ? quality : undefined
 
-				// Allow intercepting the conversion with a custom converter
-				const payload = {
-					ctx, width, height, quality: q,
-				}
-				const updatedBlob = await applyFiltersAsync( 'cimo.convertImage.intercept', fileItem.file, outputFormat, payload )
-				if ( updatedBlob instanceof Blob ) {
-					resolve( updatedBlob )
-					return
-				}
-
-				canvas.toBlob( function( blob ) {
+				// Define a cleanup function to revoke object URLs and clear canvas resources
+				const cleanup = () => {
 					// Clean up resources
 					URL.revokeObjectURL( objectUrl )
 					objectUrl = null
@@ -196,6 +187,28 @@ class ImageConverter extends Converter {
 					ctx.clearRect( 0, 0, canvas.width, canvas.height )
 					canvas.width = 0
 					canvas.height = 0
+				}
+
+				// Allow intercepting the conversion with a custom converter
+				const payload = {
+					ctx, width, height, quality: q,
+				}
+				const updatedBlob = await applyFiltersAsync(
+					'cimo.convertImage.intercept',
+					fileItem.file,
+					outputFormat,
+					payload
+
+				)
+
+				if ( updatedBlob instanceof Blob ) {
+					cleanup()
+					resolve( updatedBlob )
+					return
+				}
+
+				canvas.toBlob( function( blob ) {
+					cleanup()
 
 					if ( blob ) {
 						resolve( blob )

--- a/src/shared/converters/image-converter.js
+++ b/src/shared/converters/image-converter.js
@@ -1,5 +1,6 @@
 import { Converter } from './converter-abstract'
 import { encode as encodeAvif } from '@jsquash/avif'
+import { isFormatSupported } from './util'
 
 // Supported output formats
 const supportedFormats = [
@@ -240,8 +241,7 @@ class ImageConverter extends Converter {
 		}
 
 		// Check if the browser supports the desired output format
-		const testCanvas = document.createElement( 'canvas' )
-		if ( formatInfo && ! testCanvas.toDataURL( formatInfo.mimeType ).startsWith( `data:${ formatInfo.mimeType }` ) ) {
+		if ( ! await isFormatSupported( format ) ) {
 			// If not supported, skip conversion and return the original file
 			// eslint-disable-next-line no-console
 			console.error( '[Cimo] ' + format + ' is not supported by the browser, please use another modern browser' )

--- a/src/shared/converters/image-converter.js
+++ b/src/shared/converters/image-converter.js
@@ -1,6 +1,8 @@
 import { Converter } from './converter-abstract'
 import { isFormatSupported } from './util'
 
+import { applyFilters, applyFiltersAsync } from '@wordpress/hooks'
+
 // Supported output formats
 const supportedFormats = [
 	{ value: 'webp', mimeType: 'image/webp' },
@@ -16,13 +18,12 @@ const supportedFormats = [
 class ImageConverter extends Converter {
 	static get mimeTypes() {
 		// Accept all images supported by most browsers for conversion.
-		return [
+		return applyFilters( 'cimo.imageConverter.mimeTypes', [
 			'image/jpeg',
 			'image/png',
 			'image/webp',
 			'image/jpg',
-			'image/avif',
-		]
+		] )
 	}
 
 	static get showProgress() {
@@ -176,35 +177,32 @@ class ImageConverter extends Converter {
 				// Only use quality for lossy formats
 				const q = ( outputFormat === 'webp' || outputFormat === 'jpg' || outputFormat === 'avif' ) ? quality : undefined
 
-				if ( outputFormat === 'avif' ) {
-					try {
-						const { encode: encodeAvif } = await import( '@jsquash/avif' )
-						const imageData = ctx.getImageData( 0, 0, width, height )
-						const avifQuality = Math.max( 1, Math.min( 100, Math.round( ( ( q ?? 0.5 ) * 100 ) ) ) )
-						const avifBuffer = await encodeAvif( imageData, { quality: avifQuality } )
-						const avifBlob = new Blob( [ avifBuffer ], { type: 'image/avif' } )
-						resolve( avifBlob )
-					} catch ( e ) {
-						reject( new Error( `Failed to encode AVIF: ${ e instanceof Error ? e.message : 'Unknown error' }` ) )
-					}
-				} else {
-					canvas.toBlob( function( blob ) {
-						// Clean up resources
-						URL.revokeObjectURL( objectUrl )
-						objectUrl = null
-
-						// Clear canvas to free memory
-						ctx.clearRect( 0, 0, canvas.width, canvas.height )
-						canvas.width = 0
-						canvas.height = 0
-
-						if ( blob ) {
-							resolve( blob )
-						} else {
-							reject( new Error( 'Failed to convert image' ) )
-						}
-					}, format.mimeType, q )
+				// Allow intercepting the conversion with a custom converter
+				const payload = {
+					ctx, width, height, quality: q,
 				}
+				const updatedBlob = await applyFiltersAsync( 'cimo.convertImage.intercept', fileItem.file, outputFormat, payload )
+				if ( updatedBlob instanceof Blob ) {
+					resolve( updatedBlob )
+					return
+				}
+
+				canvas.toBlob( function( blob ) {
+					// Clean up resources
+					URL.revokeObjectURL( objectUrl )
+					objectUrl = null
+
+					// Clear canvas to free memory
+					ctx.clearRect( 0, 0, canvas.width, canvas.height )
+					canvas.width = 0
+					canvas.height = 0
+
+					if ( blob ) {
+						resolve( blob )
+					} else {
+						reject( new Error( 'Failed to convert image' ) )
+					}
+				}, format.mimeType, q )
 			}
 
 			img.onerror = () => {

--- a/src/shared/converters/image-converter.js
+++ b/src/shared/converters/image-converter.js
@@ -188,30 +188,22 @@ class ImageConverter extends Converter {
 					}
 				} else {
 					canvas.toBlob( function( blob ) {
+						// Clean up resources
+						URL.revokeObjectURL( objectUrl )
+						objectUrl = null
+
+						// Clear canvas to free memory
+						ctx.clearRect( 0, 0, canvas.width, canvas.height )
+						canvas.width = 0
+						canvas.height = 0
+
 						if ( blob ) {
 							resolve( blob )
 						} else {
 							reject( new Error( 'Failed to convert image' ) )
 						}
-					}, format.mimeType, quality )
+					}, format.mimeType, q )
 				}
-
-				canvas.toBlob( function( blob ) {
-					// Clean up resources
-					URL.revokeObjectURL( objectUrl )
-					objectUrl = null
-
-					// Clear canvas to free memory
-					ctx.clearRect( 0, 0, canvas.width, canvas.height )
-					canvas.width = 0
-					canvas.height = 0
-
-					if ( blob ) {
-						resolve( blob )
-					} else {
-						reject( new Error( 'Failed to convert image' ) )
-					}
-				}, format.mimeType, q )
 			}
 
 			img.onerror = () => {

--- a/src/shared/converters/image-converter.js
+++ b/src/shared/converters/image-converter.js
@@ -1,5 +1,4 @@
 import { Converter } from './converter-abstract'
-import { encode as encodeAvif } from '@jsquash/avif'
 import { isFormatSupported } from './util'
 
 // Supported output formats
@@ -179,6 +178,7 @@ class ImageConverter extends Converter {
 
 				if ( outputFormat === 'avif' ) {
 					try {
+						const { encode: encodeAvif } = await import( '@jsquash/avif' )
 						const imageData = ctx.getImageData( 0, 0, width, height )
 						const avifQuality = Math.max( 1, Math.min( 100, Math.round( ( ( q ?? 0.5 ) * 100 ) ) ) )
 						const avifBuffer = await encodeAvif( imageData, { quality: avifQuality } )

--- a/src/shared/converters/image-converter.js
+++ b/src/shared/converters/image-converter.js
@@ -201,10 +201,9 @@ class ImageConverter extends Converter {
 				}
 				const updatedBlob = await applyFiltersAsync(
 					'cimo.convertImage.intercept',
-					fileItem.file,
+					null,
 					outputFormat,
 					payload
-
 				)
 
 				if ( updatedBlob instanceof Blob ) {

--- a/src/shared/converters/image-converter.js
+++ b/src/shared/converters/image-converter.js
@@ -1,10 +1,12 @@
 import { Converter } from './converter-abstract'
+import { encode as encodeAvif } from '@jsquash/avif'
 
 // Supported output formats
 const supportedFormats = [
 	{ value: 'webp', mimeType: 'image/webp' },
 	{ value: 'jpg', mimeType: 'image/jpeg' },
 	{ value: 'png', mimeType: 'image/png' },
+	{ value: 'avif', mimeType: 'image/avif' },
 ]
 
 /**
@@ -19,6 +21,7 @@ class ImageConverter extends Converter {
 			'image/png',
 			'image/webp',
 			'image/jpg',
+			'image/avif',
 		]
 	}
 
@@ -171,7 +174,27 @@ class ImageConverter extends Converter {
 
 				const format = supportedFormats.find( f => f.value === outputFormat )
 				// Only use quality for lossy formats
-				const q = ( outputFormat === 'webp' || outputFormat === 'jpg' ) ? quality : undefined
+				const q = ( outputFormat === 'webp' || outputFormat === 'jpg' || outputFormat === 'avif' ) ? quality : undefined
+
+				if ( outputFormat === 'avif' ) {
+					try {
+						const imageData = ctx.getImageData( 0, 0, width, height )
+						const avifQuality = Math.max( 1, Math.min( 100, Math.round( ( ( q ?? 0.5 ) * 100 ) ) ) )
+						const avifBuffer = await encodeAvif( imageData, { quality: avifQuality } )
+						const avifBlob = new Blob( [ avifBuffer ], { type: 'image/avif' } )
+						resolve( avifBlob )
+					} catch ( e ) {
+						reject( new Error( `Failed to encode AVIF: ${ e instanceof Error ? e.message : 'Unknown error' }` ) )
+					}
+				} else {
+					canvas.toBlob( function( blob ) {
+						if ( blob ) {
+							resolve( blob )
+						} else {
+							reject( new Error( 'Failed to convert image' ) )
+						}
+					}, format.mimeType, quality )
+				}
 
 				canvas.toBlob( function( blob ) {
 					// Clean up resources

--- a/src/shared/converters/index.js
+++ b/src/shared/converters/index.js
@@ -1,6 +1,7 @@
 import { ImageConverter } from './image-converter'
 import { NullConverter } from './null-converter'
 import { applyFilters } from '@wordpress/hooks'
+import { isFormatSupported } from './util'
 
 /**
  * Get the file converter for the given file.
@@ -68,41 +69,3 @@ export function requiresFileConversion( converters ) {
 	return ! converters.every( converter => converter.constructor.name === 'NullConverter' )
 }
 
-/**
- * Check if a specific image format is supported by the browser
- *
- * @param {string} format - Format name ('webp', 'jpg', 'png', 'avif') or MIME type ('image/webp')
- * @return {boolean} - True if format is supported, false otherwise
- */
-function isFormatSupported( format ) {
-	if ( ! format || typeof format !== 'string' ) {
-		return false
-	}
-
-	// Map format names to MIME types
-	const formatMap = {
-		webp: 'image/webp',
-		avif: 'image/avif',
-	}
-
-	// Get MIME type (either from map or use as-is if already a MIME type)
-	const mimeType = formatMap[ format.toLowerCase() ] || ( format.startsWith( 'image/' ) ? format : null )
-
-	if ( ! mimeType ) {
-		return false
-	}
-
-	// Create a test canvas and check if toDataURL supports the format
-	const canvas = document.createElement( 'canvas' )
-	canvas.width = 1
-	canvas.height = 1
-
-	try {
-		const dataUrl = canvas.toDataURL( mimeType )
-		// If the browser doesn't support the format, it falls back to image/png
-		// Check if the data URL starts with the requested mime type
-		return dataUrl.startsWith( `data:${ mimeType }` )
-	} catch ( e ) {
-		return false
-	}
-}

--- a/src/shared/converters/index.js
+++ b/src/shared/converters/index.js
@@ -39,18 +39,30 @@ export const getFileConverter = async _file => {
 	}
 
 	if ( file.type.startsWith( 'image/' ) ) {
-		const imageOutputFormat = window.cimoSettings?.imageOutputFormat || 'webp'
-		// If the browser doesn't support set output format, then we can't convert it.
-		if ( ! await isFormatSupported( imageOutputFormat ) ) {
+		const settings = window.cimoSettings ?? {}
+
+		// If in free version, immediately fallback to webp
+		let outputFormat = ! settings.isPremium ? 'webp' : settings.imageOutputFormat || 'webp'
+		let isSupported = await isFormatSupported( outputFormat )
+
+		// If format set by the user is avif, but the browser does not support it
+		// fallback to webp
+		if ( outputFormat === 'avif' && ! isSupported ) {
+			outputFormat = 'webp'
+			isSupported = await isFormatSupported( outputFormat )
+		}
+
+		// If the browser doesn't support set output format, or the initial mime type
+		// is not supported, then we can't convert it.
+		if ( ! isSupported || ! ImageConverter.supportsMimeType( file.type ) ) {
 			return new NullConverter( file )
 		}
-		if ( ImageConverter.supportsMimeType( file.type ) ) {
-			return new ImageConverter( file, {
-				format: imageOutputFormat,
-				quality: window.cimoSettings?.webpQuality || 0.8,
-				maxDimension: window.cimoSettings?.maxImageDimension || 0,
-			} )
-		}
+
+		return new ImageConverter( file, {
+			format: outputFormat,
+			quality: settings.webpQuality ?? 0.8,
+			maxDimension: settings.maxImageDimension ?? 0,
+		} )
 	}
 
 	return applyFilters( 'cimo.getFileConverter', null, file ) || ( new NullConverter( file ) )

--- a/src/shared/converters/index.js
+++ b/src/shared/converters/index.js
@@ -38,13 +38,14 @@ export const getFileConverter = _file => {
 	}
 
 	if ( file.type.startsWith( 'image/' ) ) {
-		// If the browser doesn't support webp, then we can't convert it.
-		if ( ! isFormatSupported( 'webp' ) ) {
+		const imageOutputFormat = window.cimoSettings?.imageOutputFormat || 'webp'
+		// If the browser doesn't support set output format, then we can't convert it.
+		if ( ! isFormatSupported( imageOutputFormat ) ) {
 			return new NullConverter( file )
 		}
 		if ( ImageConverter.supportsMimeType( file.type ) ) {
 			return new ImageConverter( file, {
-				format: 'webp',
+				format: imageOutputFormat,
 				quality: window.cimoSettings?.webpQuality || 0.8,
 				maxDimension: window.cimoSettings?.maxImageDimension || 0,
 			} )

--- a/src/shared/converters/index.js
+++ b/src/shared/converters/index.js
@@ -9,7 +9,7 @@ import { isFormatSupported } from './util'
  * @param {File} _file - The file to get the converter for.
  * @return {Converter} - The file converter.
  */
-export const getFileConverter = _file => {
+export const getFileConverter = async _file => {
 	let file = _file
 	// In some cases (e.g., when called from an iframe), the File object may come from a different window context,
 	// so instanceof File can fail even if it's a valid File. Instead, check for file-like shape.
@@ -41,7 +41,7 @@ export const getFileConverter = _file => {
 	if ( file.type.startsWith( 'image/' ) ) {
 		const imageOutputFormat = window.cimoSettings?.imageOutputFormat || 'webp'
 		// If the browser doesn't support set output format, then we can't convert it.
-		if ( ! isFormatSupported( imageOutputFormat ) ) {
+		if ( ! await isFormatSupported( imageOutputFormat ) ) {
 			return new NullConverter( file )
 		}
 		if ( ImageConverter.supportsMimeType( file.type ) ) {

--- a/src/shared/converters/util.js
+++ b/src/shared/converters/util.js
@@ -52,8 +52,6 @@ export async function isFormatSupported( format ) {
 			// If the browser doesn't support the format, it falls back to image/png
 			// Check if the data URL starts with the requested mime type
 			supported = dataUrl.startsWith( `data:${ mimeType }` )
-
-			return supported
 		} catch ( e ) {
 			supported = false
 		}

--- a/src/shared/converters/util.js
+++ b/src/shared/converters/util.js
@@ -1,0 +1,76 @@
+// Cache for format support results to avoid redundant checks
+const formatSupportCache = {}
+
+/**
+ * Check if a specific image format is supported by the browser
+ *
+ * @param {string} format - Format name ('webp', 'jpg', 'png', 'avif') or MIME type ('image/webp')
+ * @return {boolean} - True if format is supported, false otherwise
+ */
+export async function isFormatSupported( format ) {
+	if ( ! format || typeof format !== 'string' ) {
+		return false
+	}
+
+	const key = format.toLowerCase()
+
+	// Return cached result if already checked
+	if ( key in formatSupportCache ) {
+		return formatSupportCache[ key ]
+	}
+
+	// Map format names to MIME types
+	const formatMap = {
+		webp: 'image/webp',
+		avif: 'image/avif',
+	}
+
+	// Get MIME type (either from map or use as-is if already a MIME type)
+	const mimeType =
+		formatMap[ key ] || ( key.startsWith( 'image/' ) ? key : null )
+
+	if ( ! mimeType ) {
+		formatSupportCache[ key ] = false
+		return false
+	}
+
+	let supported = false
+
+	// Check for AVIF decoding support first since it may not be supported even
+	// if the library can encode it. If the browser can't decode it, then
+	// it's not useful to convert to AVIF.
+	if ( key === 'avif' ) {
+		 supported = await supportsAvifDecode()
+	} else {
+		// Create a test canvas and check if toDataURL supports the format
+		const canvas = document.createElement( 'canvas' )
+		canvas.width = 1
+		canvas.height = 1
+
+		try {
+			const dataUrl = canvas.toDataURL( mimeType )
+			// If the browser doesn't support the format, it falls back to image/png
+			// Check if the data URL starts with the requested mime type
+			supported = dataUrl.startsWith( `data:${ mimeType }` )
+
+			return supported
+		} catch ( e ) {
+			supported = false
+		}
+	}
+
+	formatSupportCache[ key ] = supported
+	return supported
+}
+
+function supportsAvifDecode() {
+	return new Promise( resolve => {
+		const img = new Image()
+
+		img.onload = () => resolve( true )
+		img.onerror = () => resolve( false )
+
+		img.src =
+			'data:image/avif;base64,AAAAIGZ0eXBhdmlmAAAAAGF2aWZtaWYxbWlhZk1BMUIAAADybWV0YQAAAAAAAAAoaGRscgAAAAAAAAAAcGljdAAAAAAAAAAAAAAAAGxpYmF2aWYAAAAADnBpdG0AAAAAAAEAAAAeaWxvYwAAAABEAAABAAEAAAABAAABGgAAAB0AAAAoaWluZgAAAAAAAQAAABppbmZlAgAAAAABAABhdjAxQ29sb3IAAAAAamlwcnAAAABLaXBjbwAAABRpc3BlAAAAAAAAAAIAAAACAAAAEHBpeGkAAAAAAwgICAAAAAxhdjFDgQ0MAAAAABNjb2xybmNseAACAAIAAYAAAAAXaXBtYQAAAAAAAAABAAEEAQKDBAAAACVtZGF0EgAKCBgANogQEAwgMg8f8D///8WfhwB8+ErK42A='
+	} )
+}


### PR DESCRIPTION
fixes #27 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AVIF added as an image output option alongside WebP; admin settings let you choose output format (AVIF disabled on free plans).

* **Improvements**
  * Browser capability checks with caching ensure AVIF is only used when supported and otherwise fall back to the original file.
  * File uploads now detect converter support asynchronously so conversions proceed reliably across multiple files.
  * Added an interception point allowing extensions to customize image conversion output.

* **Chores**
  * Added a runtime dependency to support AVIF encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->