### PR TITLE
fix: allow adding an error note in media library and metabox

### DIFF
--- a/src/admin/class-meta-box.php
+++ b/src/admin/class-meta-box.php
@@ -85,6 +85,23 @@ if ( ! class_exists( 'Cimo_Meta_Box' ) ) {
 
 						$cimo = $metadata['cimo'];
 
+						$converted_format_raw = isset( $cimo['convertedFormat'] ) ? $cimo['convertedFormat'] : ( isset( $post->post_mime_type ) ? $post->post_mime_type : '' );
+						$converted_format = $converted_format_raw ? cimo_convert_mimetype_to_format( $converted_format_raw ) : '';
+						$media_type_label = cimo_get_media_type_label( $converted_format_raw );
+
+						if ( isset( $cimo['errorName'] ) ) {
+							echo '<div class="cimo-media-manager-metadata-title-container">';
+							echo '<h3 class="cimo-media-manager-metadata-title">' . sprintf( esc_html__( '%s Conversion Skipped', 'cimo-image-optimizer' ), esc_html( $media_type_label ) ) . '</h3>';
+							echo '</div>';
+
+							if ( $cimo['errorName'] === 'FileSizeExceededError' ) {
+								echo'<p>The WebP version of this image was larger than the original, so the original file was kept instead.</p>';
+								echo '<p>You can try lowering the image quality setting to generate a smaller WebP file.</p>';
+								echo '<p>Change the file type if needed.</p>';
+							}
+							return;
+						}
+
 						// Calculate optimization savings
 						$compression_savings = isset( $cimo['compressionSavings'] ) ? floatval( $cimo['compressionSavings'] ) : null;
 						$optimization_savings = $compression_savings !== null ? number_format( 100 - ( $compression_savings * 100 ), 2 ) : null;
@@ -96,9 +113,6 @@ if ( ! class_exists( 'Cimo_Meta_Box' ) ) {
 						$original_size = cimo_format_filesize( $original_filesize );
 						$converted_size = cimo_format_filesize( $converted_filesize );
 
-						$converted_format_raw = isset( $cimo['convertedFormat'] ) ? $cimo['convertedFormat'] : ( isset( $post->post_mime_type ) ? $post->post_mime_type : '' );
-						$converted_format = $converted_format_raw ? cimo_convert_mimetype_to_format( $converted_format_raw ) : '';
-						$media_type_label = cimo_get_media_type_label( $converted_format_raw );
 						$converttime = isset( $cimo['conversionTime'] ) ? floatval( $cimo['conversionTime'] ) : null;
 						if ( $converttime !== null ) {
 							if ( $converttime < 1000 ) {

--- a/src/admin/class-metadata.php
+++ b/src/admin/class-metadata.php
@@ -46,6 +46,7 @@ if ( ! class_exists( 'Cimo_Metadata' ) ) {
 								'convertedFilesize',
 								'conversionTime',
 								'compressionSavings',
+								'errorName'
 							];
 							if ( ! is_array( $value ) ) {
 								// translators: The %s is the parameter name.
@@ -85,6 +86,7 @@ if ( ! class_exists( 'Cimo_Metadata' ) ) {
 								'convertedFilesize',
 								'conversionTime',
 								'compressionSavings',
+								'errorName'
 							];
 							$sanitized = [];
 							if ( is_array( $value ) ) {
@@ -137,6 +139,7 @@ if ( ! class_exists( 'Cimo_Metadata' ) ) {
 				'convertedFilesize',
 				'conversionTime',
 				'compressionSavings',
+				'errorName'
 			];
 			$sanitized_metadata = [];
 			foreach ( $metadata_array as $item ) {

--- a/src/admin/css/index.css
+++ b/src/admin/css/index.css
@@ -20,7 +20,13 @@
 		margin-top: -1px;
 		fill: #19af19;
 	}
+
+	svg.error {
+		fill: #b31515;
+	}
 }
+
+
 
 .cimo-media-manager-metadata ul {
 	list-style: none;

--- a/src/admin/js/media-manager/drop-zone.js
+++ b/src/admin/js/media-manager/drop-zone.js
@@ -95,7 +95,17 @@ function addDropZoneListenerToMediaManager( targetDocument ) {
 					hasError = true
 					// eslint-disable-next-line no-console
 					console.warn( error )
-					return { file: converter.file, metadata: null }
+
+					// Add the error name in the metadata for selected error for displaying
+					// as a note.
+					const metadata = error.isDisplayNote ? {
+						filename: converter.file.name,
+						errorName: error.name,
+					} : null
+
+					return {
+						file: converter.file, metadata,
+					}
 				}
 			} )
 		)

--- a/src/admin/js/media-manager/select-files.js
+++ b/src/admin/js/media-manager/select-files.js
@@ -87,7 +87,17 @@ function addSelectFilesListenerToFileUploads( targetDocument ) {
 					hasError = true
 					// eslint-disable-next-line no-console
 					console.warn( error )
-					return { file: converter.file, metadata: null }
+
+					// Add the error name in the metadata for selected error for displaying
+					// as a note.
+					const metadata = error.isDisplayNote ? {
+						filename: converter.file.name,
+						errorName: error.name,
+					} : null
+
+					return {
+						file: converter.file, metadata,
+					}
 				}
 			} )
 		)

--- a/src/admin/js/media-manager/sidebar-info.js
+++ b/src/admin/js/media-manager/sidebar-info.js
@@ -93,11 +93,27 @@ function injectCimoMetadata( {
 	const convertedFormatRaw = customMetadata.convertedFormat || model.get( 'mime' ) || ''
 	const mediaTypeLabel = getMediaTypeLabel( convertedFormatRaw )
 
-	let html = `
+	let html = ''
+
+	if ( customMetadata.errorName ) {
+		html = `
+			<div class="cimo-media-manager-metadata-title-container">
+				<h3 class="cimo-media-manager-metadata-title">
+					${ escape( sprintf( __( '%s Conversion Skipped', 'cimo-image-optimizer' ), mediaTypeLabel ) ) }
+				</h3>
+			</div>
+		`
+		if ( customMetadata.errorName === 'FileSizeExceededError' ) {
+			html += `
+				<p>The WebP version of this image was larger than the original, so the original file was kept instead.</p>
+				<p>You can try lowering the image quality setting to generate a smaller WebP file.</p>
+				<p>Change the file type if needed.</p>
+			`
+		}
+	} else {
+		html = `
 		<div class="cimo-media-manager-metadata-title-container">
-			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 672 672" height="20" width="20">
-				<path d="M132.5 132.5C182.4 82.5 253 56 336 56C419 56 489.6 82.5 539.5 132.5C589.4 182.5 616 253 616 336C616 419 589.5 489.6 539.5 539.5C489.5 589.4 419 616 336 616C253 616 182.4 589.5 132.5 539.5C82.6 489.5 56 419 56 336C56 253 82.5 182.4 132.5 132.5z"/>
-			</svg>
+			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 672 672" height="20" width="20"><path d="M132.5 132.5C182.4 82.5 253 56 336 56C419 56 489.6 82.5 539.5 132.5C589.4 182.5 616 253 616 336C616 419 589.5 489.6 539.5 539.5C489.5 589.4 419 616 336 616C253 616 182.4 589.5 132.5 539.5C82.6 489.5 56 419 56 336C56 253 82.5 182.4 132.5 132.5zM465.5 273.9C477.6 264.2 479.5 246.6 469.9 234.5C460.3 222.4 442.6 220.5 430.5 230.1C378 272.1 330.3 341.9 306.7 379.4C291.4 359.3 267.2 331.1 239.5 312.6C226.6 304 209.2 307.5 200.7 320.4C192.2 333.3 195.6 350.7 208.5 359.2C237.4 378.5 264.1 415.1 274.1 429.9C281.5 440.9 294 447.9 307.9 447.9C322.3 447.9 335.5 440.3 342.8 428C357.2 403.5 410 318.3 465.6 273.8z"/></svg>
 			<h3 class="cimo-media-manager-metadata-title">
 				${ escape( sprintf( __( '%s Optimized by Cimo', 'cimo-image-optimizer' ), mediaTypeLabel ) ) }
 			</h3>
@@ -105,60 +121,61 @@ function injectCimoMetadata( {
 		<ul>
 	`
 
-	const optimizationSavings = customMetadata.compressionSavings
-		? ( 100 - ( customMetadata.compressionSavings * 100 ) ).toFixed( 2 )
-		: null
+		const optimizationSavings = customMetadata.compressionSavings
+			? ( 100 - ( customMetadata.compressionSavings * 100 ) ).toFixed( 2 )
+			: null
 
-	const kbSaved = formatFilesize(
-		customMetadata.originalFilesize - customMetadata.convertedFilesize,
-		1,
-		true
-	)
+		const kbSaved = formatFilesize(
+			customMetadata.originalFilesize - customMetadata.convertedFilesize,
+			1,
+			true
+		)
 
-	const optimizationSavingsClass =
+		const optimizationSavingsClass =
 		optimizationSavings > 0
 			? 'cimo-optimization-savings-up'
 			: 'cimo-optimization-savings-down'
 
-	html += `
-		<li class="cimo-compression-savings ${ escape( optimizationSavingsClass ) }">
-			Saved ${ escape( optimizationSavings ) }%
-			<span class="cimo-compression-savings-bytes">(${ escape( kbSaved ) })</span>
-		</li>
-	`
+		html += `
+			<li class="cimo-compression-savings ${ escape( optimizationSavingsClass ) }">
+				Saved ${ escape( optimizationSavings ) }%
+				<span class="cimo-compression-savings-bytes">(${ escape( kbSaved ) })</span>
+			</li>
+		`
 
-	html += `
-		<li class="cimo-filesize-original">
-			Original: <span class="cimo-value">${ escape( formatFilesize( parseInt( customMetadata.originalFilesize ) || 0 ) ) }</span>
-		</li>
-		<li class="cimo-filesize-optimized">
-			Optimized: <span class="cimo-value">${ escape( formatFilesize( parseInt( customMetadata.convertedFilesize ) || 0 ) ) }</span>
-		</li>
-	`
+		html += `
+			<li class="cimo-filesize-original">
+				Original: <span class="cimo-value">${ escape( formatFilesize( parseInt( customMetadata.originalFilesize ) || 0 ) ) }</span>
+			</li>
+			<li class="cimo-filesize-optimized">
+				Optimized: <span class="cimo-value">${ escape( formatFilesize( parseInt( customMetadata.convertedFilesize ) || 0 ) ) }</span>
+			</li>
+		`
 
-	html += `
-		<li class="cimo-converted">
-			🏞️ Converted to <span class="cimo-value">${ escape( convertMimetypeToFormat( customMetadata.convertedFormat ) ) }</span>
-		</li>
-	`
+		html += `
+			<li class="cimo-converted">
+				🏞️ Converted to <span class="cimo-value">${ escape( convertMimetypeToFormat( customMetadata.convertedFormat ) ) }</span>
+			</li>
+		`
 
-	let conversionTimeDisplay = 'N/A'
-	if ( customMetadata.conversionTime ) {
-		const timeMs = parseFloat( customMetadata.conversionTime )
-		conversionTimeDisplay =
-			timeMs < 1000
-				? `${ timeMs.toFixed( 0 ) } ms`
-				: timeMs < 60000
-					? `${ ( timeMs / 1000 ).toFixed( 1 ) } sec`
-					: `${ ( timeMs / 60000 ).toFixed( 1 ) } min`
+		let conversionTimeDisplay = 'N/A'
+		if ( customMetadata.conversionTime ) {
+			const timeMs = parseFloat( customMetadata.conversionTime )
+			conversionTimeDisplay =
+				timeMs < 1000
+					? `${ timeMs.toFixed( 0 ) } ms`
+					: timeMs < 60000
+						? `${ ( timeMs / 1000 ).toFixed( 1 ) } sec`
+						: `${ ( timeMs / 60000 ).toFixed( 1 ) } min`
+		}
+
+		html += `
+			<li class="cimo-time">
+				⚡️ Done in <span class="cimo-value">${ escape( conversionTimeDisplay ) }</span>
+			</li>
+			</ul>
+		`
 	}
-
-	html += `
-		<li class="cimo-time">
-			⚡️ Done in <span class="cimo-value">${ escape( conversionTimeDisplay ) }</span>
-		</li>
-		</ul>
-	`
 
 	customContent.innerHTML = html
 	container.appendChild( customContent )

--- a/src/shared/converters/image-converter.js
+++ b/src/shared/converters/image-converter.js
@@ -276,8 +276,11 @@ class ImageConverter extends Converter {
 			const end = performance.now()
 
 			// If the resulting image is bigger than the input, return the original file unchanged.
-			if ( convertedBlob.size > file.size ) {
-				throw new Error( `Resulting image is bigger than the input, skipping conversion.` )
+			if ( convertedBlob.size < file.size ) {
+				const error = new Error( 'Resulting image is bigger than the input, skipping conversion.' )
+				error.name = 'FileSizeExceededError'
+				error.isDisplayNote = true
+				throw error
 			}
 
 			// Get the file extension for the new format
@@ -306,7 +309,8 @@ class ImageConverter extends Converter {
 
 			return { file: outFile, metadata: conversionMetadata }
 		} catch ( error ) {
-			throw new Error( `Failed to convert image: ${ error.message }` )
+			error.message = `Failed to convert image: ${ error.message }`
+			throw error
 		}
 	}
 }


### PR DESCRIPTION
fixes #31 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error status messages now display when image conversions are skipped.
  * Added specific error notifications for file size-related conversion failures.
  * Visual error indicators appear in the media manager interface.

* **Bug Fixes**
  * Improved error handling and propagation in image conversion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->