### PR TITLE
fix: get lesser between wp threshold and user max dimension

### DIFF
--- a/src/admin/class-admin.php
+++ b/src/admin/class-admin.php
@@ -118,6 +118,7 @@ if ( ! class_exists( 'Cimo_Admin' ) ) {
 					'show_in_rest'      => [
 						'schema' => [
 							'type' => 'object',
+							'additionalProperties' => true, // If we upgrade or downgrade, the settings can possibly show as null. Prevent this.
 							'properties' => [
 								// General settings
 								'optimize_all_media' => [

--- a/src/admin/class-script-loader.php
+++ b/src/admin/class-script-loader.php
@@ -77,6 +77,10 @@ if ( ! class_exists( 'Cimo_Script_Loader' ) ) {
 			// Get current settings
 			$settings = get_option( 'cimo_options', [] );
 
+			// Expose threshold for WP Core's big image scaling.
+			// Can be false when auto scaling is disabled.
+			$threshold = apply_filters( 'big_image_size_threshold', 2560 );
+
 			// Localize script with REST API URL, nonce, and settings
 			wp_localize_script(
 				'cimo-script',
@@ -100,6 +104,7 @@ if ( ! class_exists( 'Cimo_Script_Loader' ) ) {
 					'svgUpload' => isset( $settings['svg_upload'] ) ? (int) $settings['svg_upload'] : 0,
 					'svgOptimizationEnabled' => isset( $settings['svg_optimization_enabled'] ) ? (int) $settings['svg_optimization_enabled'] : 1,
 					'stealthModeEnabled' => isset( $settings['stealth_mode_enabled'] ) ? (int) $settings['stealth_mode_enabled'] : 0,
+					'wpScalingThreshold' => $threshold,
 				]
 			);
 

--- a/src/admin/js/page/admin-settings.js
+++ b/src/admin/js/page/admin-settings.js
@@ -591,8 +591,9 @@ const AdminSettings = () => {
 								label={ __( 'Maximum Image Dimension', 'cimo-image-optimizer' ) }
 								type="number"
 								value={ settings.maxImageDimension }
+								placeholder="2560"
 								onChange={ value => handleInputChange( 'maxImageDimension', value ) }
-								help={ __( 'Maximum width or height in pixels for uploaded images. Images exceeding this dimension will be automatically resized while preserving aspect ratio. Leave empty to disable resizing. We recommend a value of 1920px.', 'cimo-image-optimizer' ) }
+								help={ __( 'Maximum width or height in pixels for uploaded images. Images exceeding this dimension will be automatically resized while preserving aspect ratio. Leave empty to use the WordPress maximum dimension (2560px). We recommend a value of 1920px.', 'cimo-image-optimizer' ) }
 								__next40pxDefaultSize
 							/>
 						</div>

--- a/src/admin/js/page/admin-settings.js
+++ b/src/admin/js/page/admin-settings.js
@@ -593,7 +593,13 @@ const AdminSettings = () => {
 								value={ settings.maxImageDimension }
 								placeholder="2560"
 								onChange={ value => handleInputChange( 'maxImageDimension', value ) }
-								help={ __( 'Maximum width or height in pixels for uploaded images. Images exceeding this dimension will be automatically resized while preserving aspect ratio. Leave empty to use the WordPress maximum dimension (2560px). We recommend a value of 1920px.', 'cimo-image-optimizer' ) }
+								help={ sprintf(
+									__( 'Maximum width or height in pixels for uploaded images. Images exceeding this dimension will be automatically resized while preserving aspect ratio. Leave empty to %s. We recommend a value of 1920px.', 'cimo-image-optimizer' ),
+									window.cimoSettings?.wpScalingThreshold
+										? sprintf( __( "use WordPress's default auto-scaling at %spx", 'cimo-image-optimizer' ), window.cimoSettings.wpScalingThreshold )
+										: __( 'disable auto-scaling', 'cimo-image-optimizer' )
+								) }
+
 								__next40pxDefaultSize
 							/>
 						</div>

--- a/src/admin/js/page/admin-settings.js
+++ b/src/admin/js/page/admin-settings.js
@@ -591,7 +591,7 @@ const AdminSettings = () => {
 								label={ __( 'Maximum Image Dimension', 'cimo-image-optimizer' ) }
 								type="number"
 								value={ settings.maxImageDimension }
-								placeholder="2560"
+								placeholder={ settings.disableWpScaling === 1 ? '2560' : undefined }
 								onChange={ value => handleInputChange( 'maxImageDimension', value ) }
 								help={ sprintf(
 									__( 'Maximum width or height in pixels for uploaded images. Images exceeding this dimension will be automatically resized while preserving aspect ratio. Leave empty to %s. We recommend a value of 1920px.', 'cimo-image-optimizer' ),

--- a/src/shared/converters/index.js
+++ b/src/shared/converters/index.js
@@ -38,6 +38,16 @@ export const getFileConverter = _file => {
 	}
 
 	if ( file.type.startsWith( 'image/' ) ) {
+		const max = parseFloat( window.cimoSettings?.maxImageDimension || 0 )
+		const wp = parseFloat( window.cimoSettings?.wpScalingThreshold || 0 )
+
+		// Determine the final max dimension to use for conversion,
+		// prioritizing the lower of the two thresholds if both are set.
+		// 0 means no max dimension.
+		const finalMaxDimension = max && wp
+			? Math.min( max, wp )
+			: max || wp || 0
+
 		// If the browser doesn't support webp, then we can't convert it.
 		if ( ! isFormatSupported( 'webp' ) ) {
 			return new NullConverter( file )
@@ -46,7 +56,7 @@ export const getFileConverter = _file => {
 			return new ImageConverter( file, {
 				format: 'webp',
 				quality: window.cimoSettings?.webpQuality || 0.8,
-				maxDimension: window.cimoSettings?.maxImageDimension || 0,
+				maxDimension: finalMaxDimension,
 			} )
 		}
 	}


### PR DESCRIPTION
fixes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings now respect WordPress’s image auto-scaling threshold in addition to the app’s max image dimension.
  * Maximum Image Dimension field shows a 2560 placeholder when WP scaling is disabled; help text now explains using the WP threshold when available.

* **Bug Fixes**
  * Image resizing uses the more restrictive value between the app setting and the WordPress threshold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->