### PR TITLE
fix: add indicator for notifications

### DIFF
--- a/src/admin/class-admin.php
+++ b/src/admin/class-admin.php
@@ -37,10 +37,16 @@ if ( ! class_exists( 'Cimo_Admin' ) ) {
 		 */
 		public function add_admin_menu() {
 			$settings = get_option( 'cimo_options', [] );
+			$menu_title = __( 'Cimo', 'cimo-image-optimizer' );
+
+			// Use cached stats here so every admin page load does not scan attachment metadata.
+			if ( class_exists( 'Cimo_Stats' ) && Cimo_Stats::should_show_rating_notice() ) {
+				$menu_title .= ' <span class="update-plugins count-1"><span class="plugin-count">' . number_format_i18n( 1 ) . '</span></span>';
+			}
 
 			add_options_page(
 				__( 'Cimo Settings', 'cimo-image-optimizer' ),
-				__( 'Cimo', 'cimo-image-optimizer' ),
+				$menu_title,
 				'manage_options',
 				CIMO_SETTINGS_SLUG,
 				[ $this, 'admin_page_callback' ]
@@ -269,6 +275,7 @@ if ( ! class_exists( 'Cimo_Admin' ) ) {
 
 			// Get statistics data
 			$stats = Cimo_Stats::get_formatted_stats();
+			$show_rating_notice = Cimo_Stats::should_show_rating_notice();
 
 			// Get image sizes
 			$image_sizes = $this->get_all_image_sizes();
@@ -286,6 +293,7 @@ if ( ! class_exists( 'Cimo_Admin' ) ) {
 				'stats' => $stats,
 				'imageSizes' => $formatted_sizes,
 				'ratingDismissed' => '1' === get_option( 'cimo_rating_dismissed', '0' ) ? '1' : '0',
+				'showRatingNotice' => $show_rating_notice ? '1' : '0',
 				'isPremium' => CIMO_BUILD === 'premium',
 				'uploadsUrl' => wp_upload_dir()['baseurl'],
 			] );

--- a/src/admin/class-metadata.php
+++ b/src/admin/class-metadata.php
@@ -266,6 +266,11 @@ if ( ! class_exists( 'Cimo_Metadata' ) ) {
 
 			// Update the attachment metadata.
 			update_post_meta( $attachment_id, '_wp_attachment_metadata', $metadata );
+
+			// Trigger a stats update after adding a new metadata.
+			if ( class_exists( 'Cimo_Stats' ) ) {
+				Cimo_Stats::get_stats();
+			}
 		}
 
 		/**

--- a/src/admin/class-stats.php
+++ b/src/admin/class-stats.php
@@ -12,6 +12,7 @@ if ( ! class_exists( 'Cimo_Stats' ) ) {
 	class Cimo_Stats {
 		const OPTION_KEY = 'cimo_stats_data';
 		const CIMO_META_STRING = 's:4:"cimo";';
+		const RATING_NOTICE_THRESHOLD_BYTES = 5242880; // 5 MB.
 
 		/**
 		 * Get all media optimization statistics
@@ -153,6 +154,37 @@ if ( ! class_exists( 'Cimo_Stats' ) ) {
 				'total_storage_saved' => self::format_bytes( $bytes_saved ),
 				'last_processed_post_id' => $stats['last_processed_post_id'] ?? 0,
 			];
+		}
+
+		/**
+		 * Check if the rating notice should be shown using cached stats only.
+		 *
+		 * This intentionally avoids calling get_stats() so admin menu rendering
+		 * does not trigger attachment metadata compute on every admin page load.
+		 */
+		public static function should_show_rating_notice() {
+			if ( '1' === get_option( 'cimo_rating_dismissed', '0' ) ) {
+				return false;
+			}
+
+			return self::get_cached_saved_bytes() >= self::RATING_NOTICE_THRESHOLD_BYTES;
+		}
+
+		/**
+		 * Get cached total saved bytes without recomputing stats.
+		 */
+		private static function get_cached_saved_bytes() {
+			$stats = get_option( self::OPTION_KEY );
+
+			if ( ! is_array( $stats ) ) {
+				return 0;
+			}
+
+			$kb_before = (float) ( $stats['total_original_size'] ?? 0 );
+			$kb_after  = (float) ( $stats['total_optimized_size'] ?? 0 );
+			$kb_saved  = max( 0, $kb_before - $kb_after );
+
+			return (int) round( $kb_saved * 1024 );
 		}
 
 		/**

--- a/src/admin/js/page/admin-settings.js
+++ b/src/admin/js/page/admin-settings.js
@@ -286,6 +286,9 @@ const AdminSettings = () => {
 					cimo_rating_dismissed: '1',
 				},
 			} )
+			// Keep the current admin menu in sync without waiting for a page reload.
+			document.querySelectorAll( '#adminmenu a[href*="page=cimo-settings"] .update-plugins' )
+				.forEach( indicator => indicator.remove() )
 		} catch ( error ) {
 			setIsRatingDismissed( false )
 		}
@@ -404,20 +407,8 @@ const AdminSettings = () => {
 			</div>
 
 			{ ( () => {
-				const savedStr = window.cimoAdmin?.stats?.total_storage_saved
-				let showRating = false
-				if ( typeof savedStr === 'string' ) {
-					const match = savedStr.match( /^([\d.]+)\s*([a-zA-Z]+)/ )
-					if ( match ) {
-						const num = parseFloat( match[ 1 ] )
-						const unit = match[ 2 ].toUpperCase()
-						if ( unit === 'MB' && num > 5 ) {
-							showRating = true
-						}
-					}
-				}
-
-				if ( showRating && ! isRatingDismissed ) {
+				// Show rating notice if user has saved at least 5MB and has not dismissed the notice before.
+				if ( window.cimoAdmin?.showRatingNotice === '1' && ! isRatingDismissed ) {
 					return (
 						<div className="cimo-header cimo-rating-notice">
 							<div className="cimo-rating-notice-content">

--- a/src/admin/js/page/admin-settings.js
+++ b/src/admin/js/page/admin-settings.js
@@ -429,6 +429,7 @@ const AdminSettings = () => {
 										target="_blank"
 										rel="noopener noreferrer"
 										className="cimo-rating-rate-now"
+										onClick={ handleDismissRating }
 										__next40pxDefaultSize
 									>
 										<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-star-icon lucide-star"><path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z" /></svg>


### PR DESCRIPTION
fixes #57
fixes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a rating notice badge to the Admin Settings menu once cumulative storage savings reach the 5MB threshold
  * Users can dismiss the rating notice, and the choice is remembered across sessions

* **Improvements**
  * Dismissing the rating notice now updates the admin sidebar immediately, without a page reload
  * The “Rate Now” button follows the same dismiss flow to keep the UI consistent
<!-- end of auto-generated comment: release notes by coderabbit.ai -->