### PR TITLE
Add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Cimo is a WordPress plugin (client-side image → WebP/AVIF conversion on upload). It only runs inside a WordPress install, so end-to-end testing needs a running WordPress with the built plugin activated.
+
+### Environment (already provisioned in the VM snapshot)
+- Node 22, PHP 8.3, Composer, and Docker are installed. Dependencies (`node_modules`, Composer `vendor/`) are refreshed by the startup update script.
+- Docker is required for the WordPress test environment (`@wordpress/env`). The Docker daemon is not managed by systemd here; if `docker ps` fails, start it with `sudo dockerd` (a background/tmux process) — the daemon is configured for the `fuse-overlayfs` storage driver and `iptables-legacy`.
+
+### Build / run / lint (see `package.json`, `BUILD.md`)
+- Dev (watch): `npm run start` — builds into `build/` and watches. This is the intended dev workflow.
+- One-shot build + zip: `npm run build` (its `prebuild` runs `npm run lint`, i.e. `lint:js` + `lint:css`).
+- Lint only: `npm run lint`. PHP lint: `composer run lint:php` (PHPCS, WordPress standards).
+- Built assets in `build/` must exist for the plugin to work in WordPress; `npm run start`/`build` generate them.
+
+### Shared WordPress dev environment (all three sibling plugins)
+- A `wp-env` project lives at `/home/ubuntu/wp-dev` with a `.wp-env.json` that mounts Cimo, Interactions and Stackable (by absolute path) into one WordPress site. It is kept out of the repos on purpose.
+- Start/stop: `cd /home/ubuntu/wp-dev && npx wp-env start` / `npx wp-env stop`. Run WP-CLI: `npx wp-env run cli wp <cmd>`.
+- Site: http://localhost:8888/wp-admin (user `admin`, password `password`). wp-env auto-activates the mounted plugins on start.
+- Hello-world check: upload a JPG/PNG via an Image block in the editor; Cimo converts it to `.webp` on upload (verify the attachment mime with `wp post list --post_type=attachment --fields=ID,post_mime_type,guid`).
+- After changing plugin source, rebuild assets (`npm run build` or keep `npm run start` watching); wp-env serves the repo directory live, so no reinstall is needed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an `AGENTS.md` with a `## Cursor Cloud specific instructions` section so future cloud agents can build, run and test the Cimo plugin without rediscovering setup.

This is a docs-only change (no code changes). The dev environment was set up and verified end-to-end:

- Installed Node 22 deps (`npm install`) and Composer deps (`svg-sanitize`, PHPCS).
- `npm run build` compiled assets into `build/` and produced `dist/cimo-1.4.1.zip` (its `prebuild` `npm run lint` passed).
- Ran WordPress via `@wordpress/env` (Docker) at `http://localhost:8888`, plugin auto-activated with no PHP errors.

## Hello-world verification

Uploaded a `.jpg` via an Image block in the editor; Cimo converted it to WebP on upload. Confirmed the attachment mime is `image/webp` via WP-CLI.

[cimo_webp_conversion_demo.mp4](https://cursor.com/agents/bc-bd4c2627-aa36-42fa-99d5-94372e57e7ba/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcimo_webp_conversion_demo.mp4)

[Media sidebar showing the uploaded file converted to .webp](https://cursor.com/agents/bc-bd4c2627-aa36-42fa-99d5-94372e57e7ba/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcimo_webp_sidebar.webp)

## Notes

- Docker is required for `@wordpress/env` and is not managed by systemd in the VM; start with `sudo dockerd` if `docker ps` fails.
- The shared `wp-env` config (mounting Cimo, Interactions and Stackable) is kept at `/home/ubuntu/wp-dev`, out of the repo on purpose.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd4c2627-aa36-42fa-99d5-94372e57e7ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd4c2627-aa36-42fa-99d5-94372e57e7ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

